### PR TITLE
Dismissable flash messages functionality

### DIFF
--- a/src/Core.Flash/Flasher.cs
+++ b/src/Core.Flash/Flasher.cs
@@ -15,10 +15,10 @@ namespace Core.Flash
             tempData = factory.GetTempData(contextAccessor.HttpContext);
         }
 
-        public void Flash(string type, string message)
+        public void Flash(string type, string message, bool dismissable = false)
         {
             var messages = tempData.Get<Queue<Message>>(Constants.Key) ?? new Queue<Message>();
-            messages.Enqueue(new Message(type, message));
+            messages.Enqueue(new Message(type, message, dismissable));
             tempData.Put(Constants.Key, messages);
         }
     }

--- a/src/Core.Flash/IFlasher.cs
+++ b/src/Core.Flash/IFlasher.cs
@@ -4,6 +4,6 @@ namespace Core.Flash
 {
     public interface IFlasher
     {
-        void Flash(string type, string message);
+        void Flash(string type, string message, bool dismissable = false);
     }
 }

--- a/src/Core.Flash/Model/Message.cs
+++ b/src/Core.Flash/Model/Message.cs
@@ -4,11 +4,13 @@
     {
         public string Type { get; }
         public string Text { get; }
+        public bool Dismissable { get; }
 
-        public Message(string type, string text)
+        public Message(string type, string text, bool dismissable)
         {
             Type = type;
             Text = text;
+            Dismissable = dismissable;
         }
     }
 }

--- a/src/Core.Flash/Mvc/FlashTagHelper.cs
+++ b/src/Core.Flash/Mvc/FlashTagHelper.cs
@@ -12,6 +12,15 @@ namespace Core.Flash.Mvc
     {
         private ITempDataDictionary tempData;
 
+        private const string HtmlStandardTemplate = "<div class=\"alert alert-{0}\">{1}</div>";
+
+        private const string HtmlDismissableTemplate = 
+            "<div class=\"alert alert-{0} alert-dismissible\" role=\"alert\">" +
+                "<button type=\"button\" class=\"close\" data-dismiss=\"alert\" aria-label=\"Close\">" +
+                    "<span aria-hidden=\"true\">&times;</span>" +
+                "</button>{1}" +
+            "</div>";
+
         public FlashesTagHelper(ITempDataDictionaryFactory factory, IHttpContextAccessor contextAccessor)
         {
             tempData = factory.GetTempData(contextAccessor.HttpContext);
@@ -24,7 +33,11 @@ namespace Core.Flash.Mvc
             while (messages.Count > 0)
             {
                 var message = messages.Dequeue();
-                var html = $@"<div class=""alert alert-{message.Type}"">{message.Text}</div>";
+
+                var html = message.Dismissable
+                    ? string.Format(HtmlDismissableTemplate, message.Type, message.Text)
+                    : string.Format(HtmlStandardTemplate, message.Type, message.Text);
+
                 output.Content.AppendHtml(html);
             }
         }


### PR DESCRIPTION
Dismissable flash messages allow to use flash messages that can be closed, using the **X**:
![screen shot 2018-07-28 at 9 09 37 pm](https://user-images.githubusercontent.com/1126874/43359402-a5a03652-92aa-11e8-801d-b56f016015f4.png)

This is only the extension of existing functionality, so if previously this worked:
`f.Flash("success", "Flash message system for ASP.NET MVC Core");`

Now this works as well:
`f.Flash("success", "Flash message system for ASP.NET MVC Core", dismissable: true);`