### PR TITLE
Added instant save for flashes.

### DIFF
--- a/src/Core.Flash/Flasher.cs
+++ b/src/Core.Flash/Flasher.cs
@@ -20,6 +20,7 @@ namespace Core.Flash
             var messages = tempData.Get<Queue<Message>>(Constants.Key) ?? new Queue<Message>();
             messages.Enqueue(new Message(type, message, dismissable));
             tempData.Put(Constants.Key, messages);
+            tempData.Save();
         }
     }
 }


### PR DESCRIPTION
Calling `tempData.Save()` in `Flash` method would allow to instantly persist flash info data in the `HttpContext`, thus allowing flashes to be used from mvc middleware.