### PR TITLE
Remove HttpContext access from constructor

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Core.Flash Versions">
-    <coreflash>2.1.0$(VersionSuffix)</coreflash>
+    <coreflash>2.1.1$(VersionSuffix)</coreflash>
   </PropertyGroup>
   
   <PropertyGroup Label="Package Dependencies">

--- a/src/Core.Flash/Flasher.cs
+++ b/src/Core.Flash/Flasher.cs
@@ -10,15 +10,18 @@ namespace Core.Flash
 {
     public class Flasher : IFlasher
     {
-        private readonly ITempDataDictionary tempData;
+        private readonly ITempDataDictionaryFactory tempDataDictionaryFactory;
+        private readonly IHttpContextAccessor httpContextAccessor;
 
         public Flasher(ITempDataDictionaryFactory factory, IHttpContextAccessor httpContextAccessor)
         {
-            tempData = factory.GetTempData(httpContextAccessor.HttpContext);
+            this.tempDataDictionaryFactory = factory;
+            this.httpContextAccessor = httpContextAccessor;
         }
 
         public void Flash(string type, string message, bool dismissable = false)
         {
+            var tempData = GetTempData();
             var messages = tempData.Get<Queue<Message>>(Constants.Key) ?? new Queue<Message>();
             messages.Enqueue(new Message(type, message, dismissable));
             tempData.Put(Constants.Key, messages);
@@ -27,7 +30,12 @@ namespace Core.Flash
 
         public bool Any()
         {
-            return tempData.ContainsKey(Constants.Key);
+            return GetTempData().ContainsKey(Constants.Key);
+        }
+
+        private ITempDataDictionary GetTempData()
+        {
+            return tempDataDictionaryFactory.GetTempData(httpContextAccessor.HttpContext);
         }
     }
 }

--- a/src/Core.Flash/Mvc/FlashTagHelper.cs
+++ b/src/Core.Flash/Mvc/FlashTagHelper.cs
@@ -12,7 +12,8 @@ namespace Core.Flash.Mvc
     [HtmlTargetElement("div", Attributes = "flashes")]
     public class FlashesTagHelper : TagHelper
     {
-        private readonly ITempDataDictionary tempData;
+        private readonly ITempDataDictionaryFactory tempDataDictionaryFactory;
+        private readonly IHttpContextAccessor httpContextAccessor;
 
         private const string HtmlStandardTemplate = "<div class=\"alert alert-{0}\">{1}</div>";
 
@@ -23,13 +24,15 @@ namespace Core.Flash.Mvc
                 "</button>{1}" +
             "</div>";
 
-        public FlashesTagHelper(ITempDataDictionaryFactory factory, IHttpContextAccessor contextAccessor)
+        public FlashesTagHelper(ITempDataDictionaryFactory factory, IHttpContextAccessor httpContextAccessor)
         {
-            tempData = factory.GetTempData(contextAccessor.HttpContext);
+            this.tempDataDictionaryFactory = factory;
+            this.httpContextAccessor = httpContextAccessor;
         }
 
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
+            var tempData = GetTempData();
             var messages = tempData.Get<Queue<Message>>(Constants.Key) ?? new Queue<Message>();
 
             while (messages.Count > 0)
@@ -42,6 +45,11 @@ namespace Core.Flash.Mvc
 
                 output.Content.AppendHtml(html);
             }
+        }
+
+        private ITempDataDictionary GetTempData()
+        {
+            return tempDataDictionaryFactory.GetTempData(httpContextAccessor.HttpContext);
         }
     }
 }


### PR DESCRIPTION
This PR removes the HttpContext access from the constructor(s). This is needed to prevent the DI tree from breaking when verifying it with SimpleInjector.





